### PR TITLE
Update profile.cfm

### DIFF
--- a/wwwroot/my-account/profile.cfm
+++ b/wwwroot/my-account/profile.cfm
@@ -2,7 +2,7 @@
 
 <cfif structKeyExists(form, "username")>
 	<!--- using the cfupdate tag makes my job almost too easy! --->
-	<cfupdate datasource="#application.dsn#" tablename="USERS">
+	<cfupdate datasource="#application.dsn#" tablename="users">
 	<cfset session.username = form.username>
 	<div class="alert alert-success">Your user account has been updated.</div>
 </cfif>


### PR DESCRIPTION
Changing the CASE of the sql table name. This is needed because in my test setup of coldfusion running on top of linux with mysql connector, something in the connection is case insensitve and it triggers the error handler because there is no table called USERS on unix.
Great project btw...